### PR TITLE
Case-insensitive default Locale check fix

### DIFF
--- a/src/main/java/walkingkooka/j2cl/java/util/locale/annotationprocessor/LocaleProviderAnnotationProcessor.java
+++ b/src/main/java/walkingkooka/j2cl/java/util/locale/annotationprocessor/LocaleProviderAnnotationProcessor.java
@@ -23,6 +23,7 @@ import walkingkooka.text.CharSequences;
 import walkingkooka.text.printer.IndentingPrinter;
 
 import java.io.DataOutput;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -41,18 +42,35 @@ public final class LocaleProviderAnnotationProcessor extends LocaleAwareAnnotati
     protected Optional<String> defaultValue(final Set<String> locales,
                                             final Function<String, String> arguments) {
         final String defaultLocale = arguments.apply(DEFAULT_LOCALE);
-        if (false == locales.contains(defaultLocale)) {
+
+        failIdDefaultLocaleMissing(
+                defaultLocale,
+                locales
+        );
+
+        return Optional.of(defaultLocale);
+    }
+
+    static void failIdDefaultLocaleMissing(final String defaultLocale,
+                                           final Set<String> locales) {
+        if (false == isPresent(Locale.forLanguageTag(defaultLocale), locales)) {
             throw new IllegalArgumentException(
                     "Default Locale " +
                             CharSequences.quoteAndEscape(defaultLocale) +
                             " missing from selected locales " +
                             CharSequences.quoteAndEscape(
                                     locales.stream()
-                                            .collect(Collectors.joining(","))
+                                            .collect(Collectors.joining(", "))
                             )
             );
         }
-        return Optional.of(defaultLocale);
+    }
+
+    private static boolean isPresent(final Locale defaultLocale,
+                                     final Set<String> locales) {
+        return locales.stream()
+                .map(Locale::forLanguageTag)
+                .anyMatch(defaultLocale::equals);
     }
 
     private final static String DEFAULT_LOCALE = "walkingkooka.j2cl.java.util.Locale.DEFAULT";

--- a/src/test/java/walkingkooka/j2cl/java/util/locale/annotationprocessor/LocaleProviderAnnotationProcessorTest.java
+++ b/src/test/java/walkingkooka/j2cl/java/util/locale/annotationprocessor/LocaleProviderAnnotationProcessorTest.java
@@ -18,8 +18,11 @@
 package walkingkooka.j2cl.java.util.locale.annotationprocessor;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.collect.set.Sets;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class LocaleProviderAnnotationProcessorTest implements ClassTesting<LocaleProviderAnnotationProcessor> {
 
@@ -28,6 +31,38 @@ public final class LocaleProviderAnnotationProcessorTest implements ClassTesting
         this.checkEquals(
                 JavaVisibility.PUBLIC,
                 JavaVisibility.of(LocaleProviderAnnotationProcessor.class.getConstructor())
+        );
+    }
+
+    @Test
+    public void testFailIdDefaultLocaleMissingFails() {
+        final IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleProviderAnnotationProcessor.failIdDefaultLocaleMissing(
+                        "EN-AU",
+                        Sets.of("FR", "EN-GB")
+                )
+        );
+
+        this.checkEquals(
+                "Default Locale \"EN-AU\" missing from selected locales \"FR, EN-GB\"",
+                thrown.getMessage()
+        );
+    }
+
+    @Test
+    public void testFailIdDefaultLocaleMissingDifferentCase() {
+        LocaleProviderAnnotationProcessor.failIdDefaultLocaleMissing(
+                "EN-AU",
+                Sets.of("en-AU")
+        );
+    }
+
+    @Test
+    public void testFailIdDefaultLocaleMissingSameCase() {
+        LocaleProviderAnnotationProcessor.failIdDefaultLocaleMissing(
+                "EN-AU",
+                Sets.of("en-AU")
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/j2cl-java-util-Locale-annotation-processor/issues/37
- Default locale missing check is case sensitive